### PR TITLE
Fix Triangulate_MONO for triangle input

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -1409,6 +1409,7 @@ int TPPLPartition::TriangulateMonotone(TPPLPoly *inPoly, list<TPPLPoly> *triangl
 	if(numpoints < 3) return 0;
 	if(numpoints == 3) {
 		triangles->push_back(*inPoly);
+		return 1;
 	}
 
 	topindex = 0; bottomindex=0;


### PR DESCRIPTION
Without this, "triangulating" a triangle results in two copies of itself.

By the way, this looks like a nice little library, thanks :-)  I'm considering using it for triangulating arbitrary polygons in one of my projects (https://github.com/c42f/displaz).