### PR TITLE
Vertex id

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -1409,6 +1409,7 @@ int TPPLPartition::TriangulateMonotone(TPPLPoly *inPoly, list<TPPLPoly> *triangl
 	if(numpoints < 3) return 0;
 	if(numpoints == 3) {
 		triangles->push_back(*inPoly);
+		return 1;
 	}
 
 	topindex = 0; bottomindex=0;

--- a/src/polypartition.h
+++ b/src/polypartition.h
@@ -71,10 +71,11 @@ struct TPPLPoint {
         if((x == p.x)&&(y==p.y)) return false;
         else return true;
     }
-    };
-    
-    //Polygon implemented as an array of points with a 'hole' flag
-    class TPPLPoly {
+};
+
+
+//Polygon implemented as an array of points with a 'hole' flag
+class TPPLPoly {
     protected:
         
         TPPLPoint *points;
@@ -139,9 +140,10 @@ struct TPPLPoint {
         //   TPPL_CCW : sets vertices in counter-clockwise order
         //   TPPL_CW : sets vertices in clockwise order
         void SetOrientation(int orientation);
-    };
-    
-    class TPPLPartition {
+};
+
+
+class TPPLPartition {
     protected:
         struct PartitionVertex {
             bool isActive;
@@ -344,7 +346,7 @@ struct TPPLPoint {
         //   parts : resulting list of convex polygons
         //returns 1 on success, 0 on failure
         int ConvexPartition_OPT(TPPLPoly *poly, std::list<TPPLPoly> *parts);
-    };
-    
-    
+};
+
+
 #endif

--- a/src/polypartition.h
+++ b/src/polypartition.h
@@ -33,6 +33,9 @@ typedef double tppl_float;
 struct TPPLPoint {
     tppl_float x;
     tppl_float y;
+    // User-specified vertex identifier.  Note that this isn't used internally
+    // by the library, but will be faithfully copied around.
+    int id;
     
     TPPLPoint operator + (const TPPLPoint& p) const {
         TPPLPoint r;


### PR DESCRIPTION
This patch adds a user-defined vertex id as a simple way to address issue #8.  

This enables the user to map the output vertices in the final triangles/partition back to the input vertices.  This allows additional vertex attributes to be mapped from the input vertices onto the output triangles in a straightforward way.  Choice of an integer vertex id to represent vertex properties may not be the most convenient in all cases.  A more complex alternative would be template TPPLPoint on the type of `id`, but then you'd need to pull most of the implementation into the header which seems like quite an unfortunate tradeoff.

Also included in a separate commit is a couple of whitespace changes to make indentation more consistent.  The `Triangulate_MONO` patch (pr #12) has also unfortunately infected this PR due to me sloppily making #12 off my master branch.