### PR TITLE
Fix Triangulate_MONO for triangle input

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -1409,6 +1409,7 @@ int TPPLPartition::TriangulateMonotone(TPPLPoly *inPoly, list<TPPLPoly> *triangl
 	if(numpoints < 3) return 0;
 	if(numpoints == 3) {
 		triangles->push_back(*inPoly);
+		return 1;
 	}
 
 	topindex = 0; bottomindex=0;


### PR DESCRIPTION
Without this, "triangulating" a triangle results in two copies of itself.

I'm recreating this pull request (original PR here: #12), since I made the original against my master branch, but I'd like to merge other fixes into my master.
