### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-####PolyPartition
+#### PolyPartition
 
 PolyPartition is a lightweight C++ library for polygon partition and triangulation. PolyPartition implements multiple algorithms for both convex partitioning and triangulation. Different algorithms produce different quality of results (and their complexity varies accordingly). The implemented methods/algorithms with their advantages and disadvantages are outlined below.
 
 For input parameters and return values see method declarations in `polypartition.h`. All methods require that the input polygons are not self-intersecting, and are defined in the correct vertex order (conter-clockwise for non-holes, clockwise for holes). Polygon vertices can easily be ordered correctly by calling `TPPLPoly::SetOrientation` method.
 
-####Triangulation by ear clipping
+#### Triangulation by ear clipping
 
 Method: `TPPLPartition::Triangulate_EC`
 
@@ -19,7 +19,7 @@ Example:
 ![http://polypartition.googlecode.com/svn/trunk/images/tri_ec.png](https://raw.githubusercontent.com/ivanfratric/polypartition/master/images/tri_ec.png)
 
 
-####Optimal triangulation in terms of edge length using dynamic programming algorithm
+#### Optimal triangulation in terms of edge length using dynamic programming algorithm
 
 Method: `TPPLPartition::Triangulate_OPT`
 
@@ -34,7 +34,7 @@ Example:
 ![https://raw.githubusercontent.com/ivanfratric/polypartition/master/images/tri_opt.png](https://raw.githubusercontent.com/ivanfratric/polypartition/master/images/tri_opt.png)
 
 
-####Triangulation by partition into monotone polygons
+#### Triangulation by partition into monotone polygons
 
 Method: `TPPLPartition::Triangulate_MONO`
 
@@ -49,7 +49,7 @@ Example:
 ![https://raw.githubusercontent.com/ivanfratric/polypartition/master/images/tri_mono.png](https://raw.githubusercontent.com/ivanfratric/polypartition/master/images/tri_mono.png)
 
 
-####Convex partition using Hertel-Mehlhorn algorithm
+#### Convex partition using Hertel-Mehlhorn algorithm
 
 Method: `TPPLPartition::ConvexPartition_HM`
 
@@ -64,7 +64,7 @@ Example:
 ![https://raw.githubusercontent.com/ivanfratric/polypartition/master/images/conv_hm.png](https://raw.githubusercontent.com/ivanfratric/polypartition/master/images/conv_hm.png)
 
 
-####Optimal convex partition using dynamic programming algorithm by Keil and Snoeyink
+#### Optimal convex partition using dynamic programming algorithm by Keil and Snoeyink
 
 Method: `TPPLPartition::ConvexPartition_OPT`
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
