### PR TITLE
Fixes crashes in MonotonePartition

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -1155,6 +1155,10 @@ int TPPLPartition::MonotonePartition(list<TPPLPoly> *inpolys, list<TPPLPoly> *mo
 				break;
 
 			case TPPL_VERTEXTYPE_END:
+				if (edgeTreeIterators[v->previous] == edgeTree.end()) {
+					error = true;
+					break;
+				}
 				//if helper(ei-1) is a merge vertex
 				if(vertextypes[helpers[v->previous]]==TPPL_VERTEXTYPE_MERGE) {
 					//Insert the diagonal connecting vi to helper(ei-1) in D.
@@ -1192,6 +1196,10 @@ int TPPLPartition::MonotonePartition(list<TPPLPoly> *inpolys, list<TPPLPoly> *mo
 				break;
 
 			case TPPL_VERTEXTYPE_MERGE:
+				if (edgeTreeIterators[v->previous] == edgeTree.end()) {
+					error = true;
+					break;
+				}
 				//if helper(ei-1) is a merge vertex
 				if(vertextypes[helpers[v->previous]]==TPPL_VERTEXTYPE_MERGE) {
 					//Insert the diagonal connecting vi to helper(ei-1) in D.
@@ -1224,6 +1232,10 @@ int TPPLPartition::MonotonePartition(list<TPPLPoly> *inpolys, list<TPPLPoly> *mo
 			case TPPL_VERTEXTYPE_REGULAR:
 				//if the interior of P lies to the right of vi
 				if(Below(v->p,vertices[v->previous].p)) {
+					if (edgeTreeIterators[v->previous] == edgeTree.end()) {
+						error = true;
+						break;
+					}
 					//if helper(ei-1) is a merge vertex
 					if(vertextypes[helpers[v->previous]]==TPPL_VERTEXTYPE_MERGE) {
 						//Insert the diagonal connecting vi to helper(ei-1) in D.


### PR DESCRIPTION
Hi there, `Triangulate_MONO` currently crashes in certain situations due to the deletion of an end iterator.

Here is a small test case for the crash:
[monotone-crash.zip](https://github.com/ivanfratric/polypartition/files/2014266/monotone-crash.zip)

Not sure, if this situation is recoverable (i.e. how the algorithm would continue). With this PR, at least there's no crash, but simply a fail return code.