### PR TITLE
allow custom allocators for std::list

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -25,6 +25,7 @@
 #include <list>
 #include <algorithm>
 #include <set>
+#include <vector>
 
 using namespace std;
 
@@ -171,9 +172,9 @@ int TPPLPartition::Intersects(TPPLPoint &p11, TPPLPoint &p12, TPPLPoint &p21, TP
 }
 
 //removes holes from inpolys by merging them with non-holes
-int TPPLPartition::RemoveHoles(list<TPPLPoly> *inpolys, list<TPPLPoly> *outpolys) {
-	list<TPPLPoly> polys;
-	list<TPPLPoly>::iterator holeiter,polyiter,iter,iter2;
+int TPPLPartition::RemoveHoles(TPPLPolyList *inpolys, TPPLPolyList *outpolys) {
+	TPPLPolyList polys;
+	TPPLPolyList::iterator holeiter,polyiter,iter,iter2;
 	long i,i2,holepointindex,polypointindex;
 	TPPLPoint holepoint,polypoint,bestpolypoint;
 	TPPLPoint linep1,linep2;
@@ -374,7 +375,7 @@ void TPPLPartition::UpdateVertex(PartitionVertex *v, PartitionVertex *vertices, 
 }
 
 //triangulation by ear removal
-int TPPLPartition::Triangulate_EC(TPPLPoly *poly, list<TPPLPoly> *triangles) {
+int TPPLPartition::Triangulate_EC(TPPLPoly *poly, TPPLPolyList *triangles) {
 	long numvertices;
 	PartitionVertex *vertices = NULL;
 	PartitionVertex *ear = NULL;
@@ -448,9 +449,9 @@ int TPPLPartition::Triangulate_EC(TPPLPoly *poly, list<TPPLPoly> *triangles) {
 	return 1;
 }
 
-int TPPLPartition::Triangulate_EC(list<TPPLPoly> *inpolys, list<TPPLPoly> *triangles) {
-	list<TPPLPoly> outpolys;
-	list<TPPLPoly>::iterator iter;
+int TPPLPartition::Triangulate_EC(TPPLPolyList *inpolys, TPPLPolyList *triangles) {
+	TPPLPolyList outpolys;
+	TPPLPolyList::iterator iter;
 	
 	if(!RemoveHoles(inpolys,&outpolys)) return 0;
 	for(iter=outpolys.begin();iter!=outpolys.end();iter++) {
@@ -459,9 +460,9 @@ int TPPLPartition::Triangulate_EC(list<TPPLPoly> *inpolys, list<TPPLPoly> *trian
 	return 1;
 }
 
-int TPPLPartition::ConvexPartition_HM(TPPLPoly *poly, list<TPPLPoly> *parts) {
-	list<TPPLPoly> triangles;
-	list<TPPLPoly>::iterator iter1,iter2;
+int TPPLPartition::ConvexPartition_HM(TPPLPoly *poly, TPPLPolyList *parts) {
+	TPPLPolyList triangles;
+	TPPLPolyList::iterator iter1,iter2;
 	TPPLPoly *poly1 = NULL,*poly2 = NULL;
 	TPPLPoly newpoly;
 	TPPLPoint d1,d2,p1,p2,p3;
@@ -559,9 +560,9 @@ int TPPLPartition::ConvexPartition_HM(TPPLPoly *poly, list<TPPLPoly> *parts) {
 	return 1;
 }
 
-int TPPLPartition::ConvexPartition_HM(list<TPPLPoly> *inpolys, list<TPPLPoly> *parts) {
-	list<TPPLPoly> outpolys;
-	list<TPPLPoly>::iterator iter;
+int TPPLPartition::ConvexPartition_HM(TPPLPolyList *inpolys, TPPLPolyList *parts) {
+	TPPLPolyList outpolys;
+	TPPLPolyList::iterator iter;
 	
 	if(!RemoveHoles(inpolys,&outpolys)) return 0;
 	for(iter=outpolys.begin();iter!=outpolys.end();iter++) {
@@ -573,14 +574,14 @@ int TPPLPartition::ConvexPartition_HM(list<TPPLPoly> *inpolys, list<TPPLPoly> *p
 //minimum-weight polygon triangulation by dynamic programming
 //O(n^3) time complexity
 //O(n^2) space complexity
-int TPPLPartition::Triangulate_OPT(TPPLPoly *poly, list<TPPLPoly> *triangles) {
+int TPPLPartition::Triangulate_OPT(TPPLPoly *poly, TPPLPolyList *triangles) {
 	long i,j,k,gap,n;
 	DPState **dpstates = NULL;
 	TPPLPoint p1,p2,p3,p4;
 	long bestvertex;
 	tppl_float weight,minweight,d1,d2;
 	Diagonal diagonal,newdiagonal;
-	list<Diagonal> diagonals;
+	DiagonalList diagonals;
 	TPPLPoly triangle;
 	int ret = 1;
 
@@ -705,7 +706,7 @@ int TPPLPartition::Triangulate_OPT(TPPLPoly *poly, list<TPPLPoly> *triangles) {
 
 void TPPLPartition::UpdateState(long a, long b, long w, long i, long j, DPState2 **dpstates) {
 	Diagonal newdiagonal;
-	list<Diagonal> *pairs = NULL;
+	DiagonalList *pairs = NULL;
 	long w2;
 
 	w2 = dpstates[a][b].weight;
@@ -727,8 +728,8 @@ void TPPLPartition::UpdateState(long a, long b, long w, long i, long j, DPState2
 }
 
 void TPPLPartition::TypeA(long i, long j, long k, PartitionVertex *vertices, DPState2 **dpstates) {
-	list<Diagonal> *pairs = NULL;
-	list<Diagonal>::iterator iter,lastiter;
+	DiagonalList *pairs = NULL;
+	DiagonalList::iterator iter,lastiter;
 	long top;
 	long w;
 
@@ -758,8 +759,8 @@ void TPPLPartition::TypeA(long i, long j, long k, PartitionVertex *vertices, DPS
 }
 
 void TPPLPartition::TypeB(long i, long j, long k, PartitionVertex *vertices, DPState2 **dpstates) {
-	list<Diagonal> *pairs = NULL;
-	list<Diagonal>::iterator iter,lastiter;
+	DiagonalList *pairs = NULL;
+	DiagonalList::iterator iter,lastiter;
 	long top;
 	long w;
 
@@ -791,19 +792,19 @@ void TPPLPartition::TypeB(long i, long j, long k, PartitionVertex *vertices, DPS
 	UpdateState(i,k,w,j,top,dpstates);
 }
 
-int TPPLPartition::ConvexPartition_OPT(TPPLPoly *poly, list<TPPLPoly> *parts) {
+int TPPLPartition::ConvexPartition_OPT(TPPLPoly *poly, TPPLPolyList *parts) {
 	TPPLPoint p1,p2,p3,p4;
 	PartitionVertex *vertices = NULL;
 	DPState2 **dpstates = NULL;
 	long i,j,k,n,gap;
-	list<Diagonal> diagonals,diagonals2;
+	DiagonalList diagonals,diagonals2;
 	Diagonal diagonal,newdiagonal;
-	list<Diagonal> *pairs = NULL,*pairs2 = NULL;
-	list<Diagonal>::iterator iter,iter2;
+	DiagonalList *pairs = NULL,*pairs2 = NULL;
+	DiagonalList::iterator iter,iter2;
 	int ret;
 	TPPLPoly newpoly;
-	list<long> indices;
-	list<long>::iterator iiter;
+	vector<long> indices;
+	vector<long>::iterator iiter;
 	bool ijreal,jkreal;
 
 	n = poly->GetNumPoints();
@@ -1033,7 +1034,7 @@ int TPPLPartition::ConvexPartition_OPT(TPPLPoly *poly, list<TPPLPoly> *parts) {
 			indices.push_back(j);
 		}
 
-		indices.sort();
+		std::sort(indices.begin(), indices.end());
 		newpoly.Init((long)indices.size());
 		k=0;
 		for(iiter = indices.begin();iiter!=indices.end();iiter++) {
@@ -1057,8 +1058,8 @@ int TPPLPartition::ConvexPartition_OPT(TPPLPoly *poly, list<TPPLPoly> *parts) {
 //the algorithm used here is outlined in the book
 //"Computational Geometry: Algorithms and Applications" 
 //by Mark de Berg, Otfried Cheong, Marc van Kreveld and Mark Overmars
-int TPPLPartition::MonotonePartition(list<TPPLPoly> *inpolys, list<TPPLPoly> *monotonePolys) {
-	list<TPPLPoly>::iterator iter;
+int TPPLPartition::MonotonePartition(TPPLPolyList *inpolys, TPPLPolyList *monotonePolys) {
+	TPPLPolyList::iterator iter;
 	MonotoneVertex *vertices = NULL;
 	long i,numvertices,vindex,vindex2,newnumvertices,maxnumvertices;
 	long polystartindex, polyendindex;
@@ -1412,7 +1413,7 @@ bool TPPLPartition::ScanLineEdge::operator < (const ScanLineEdge & other) const 
 
 //triangulates monotone polygon
 //O(n) time, O(n) space complexity
-int TPPLPartition::TriangulateMonotone(TPPLPoly *inPoly, list<TPPLPoly> *triangles) {
+int TPPLPartition::TriangulateMonotone(TPPLPoly *inPoly, TPPLPolyList *triangles) {
 	long i,i2,j,topindex,bottomindex,leftindex,rightindex,vindex;
 	TPPLPoint *points = NULL;
 	long numpoints;
@@ -1545,9 +1546,9 @@ int TPPLPartition::TriangulateMonotone(TPPLPoly *inPoly, list<TPPLPoly> *triangl
 	return 1;
 }
 
-int TPPLPartition::Triangulate_MONO(list<TPPLPoly> *inpolys, list<TPPLPoly> *triangles) {
-	list<TPPLPoly> monotone;
-	list<TPPLPoly>::iterator iter;
+int TPPLPartition::Triangulate_MONO(TPPLPolyList *inpolys, TPPLPolyList *triangles) {
+	TPPLPolyList monotone;
+	TPPLPolyList::iterator iter;
 
 	if(!MonotonePartition(inpolys,&monotone)) return 0;
 	for(iter = monotone.begin(); iter!=monotone.end();iter++) {
@@ -1556,8 +1557,8 @@ int TPPLPartition::Triangulate_MONO(list<TPPLPoly> *inpolys, list<TPPLPoly> *tri
 	return 1;
 }
 
-int TPPLPartition::Triangulate_MONO(TPPLPoly *poly, list<TPPLPoly> *triangles) {
-	list<TPPLPoly> polys;
+int TPPLPartition::Triangulate_MONO(TPPLPoly *poly, TPPLPolyList *triangles) {
+	TPPLPolyList polys;
 	polys.push_back(*poly);
 
 	return Triangulate_MONO(&polys, triangles);

--- a/src/polypartition.h
+++ b/src/polypartition.h
@@ -149,6 +149,11 @@ class TPPLPoly {
         void SetOrientation(int orientation);
 };
 
+#ifdef TPPL_ALLOCATOR
+typedef std::list<TPPLPoly, TPPL_ALLOCATOR(TPPLPoly)> TPPLPolyList;
+#else
+typedef std::list<TPPLPoly> TPPLPolyList;
+#endif
 
 class TPPLPartition {
     protected:
@@ -182,6 +187,12 @@ class TPPLPartition {
             long index1;
             long index2;
         };
+
+#ifdef TPPL_ALLOCATOR
+        typedef std::list<Diagonal, TPPL_ALLOCATOR(Diagonal)> DiagonalList;
+#else
+        typedef std::list<Diagonal> DiagonalList;
+#endif
         
         //dynamic programming state for minimum-weight triangulation
         struct DPState {
@@ -194,7 +205,7 @@ class TPPLPartition {
         struct DPState2 {
             bool visible;
             long weight;
-            std::list<Diagonal> pairs;
+            DiagonalList pairs;
         };
         
         //edge that intersects the scanline
@@ -238,7 +249,7 @@ class TPPLPartition {
             std::set<ScanLineEdge> *edgeTree, long *helpers);
         
         //triangulates a monotone polygon, used in Triangulate_MONO
-        int TriangulateMonotone(TPPLPoly *inPoly, std::list<TPPLPoly> *triangles);
+        int TriangulateMonotone(TPPLPoly *inPoly, TPPLPolyList *triangles);
         
     public:
         
@@ -252,7 +263,7 @@ class TPPLPartition {
         //             vertices of all hole polys have to be in clockwise order
         //   outpolys : a list of polygons without holes
         //returns 1 on success, 0 on failure
-        int RemoveHoles(std::list<TPPLPoly> *inpolys, std::list<TPPLPoly> *outpolys);
+        int RemoveHoles(TPPLPolyList *inpolys, TPPLPolyList *outpolys);
         
         //triangulates a polygon by ear clipping
         //time complexity O(n^2), n is the number of vertices
@@ -262,7 +273,7 @@ class TPPLPartition {
         //          vertices have to be in counter-clockwise order
         //   triangles : a list of triangles (result)
         //returns 1 on success, 0 on failure
-        int Triangulate_EC(TPPLPoly *poly, std::list<TPPLPoly> *triangles);
+        int Triangulate_EC(TPPLPoly *poly, TPPLPolyList *triangles);
         
         //triangulates a list of polygons that may contain holes by ear clipping algorithm
         //first calls RemoveHoles to get rid of the holes, and then Triangulate_EC for each resulting polygon
@@ -274,7 +285,7 @@ class TPPLPartition {
         //             vertices of all hole polys have to be in clockwise order
         //   triangles : a list of triangles (result)
         //returns 1 on success, 0 on failure
-        int Triangulate_EC(std::list<TPPLPoly> *inpolys, std::list<TPPLPoly> *triangles);
+        int Triangulate_EC(TPPLPolyList *inpolys, TPPLPolyList *triangles);
         
         //creates an optimal polygon triangulation in terms of minimal edge length
         //time complexity: O(n^3), n is the number of vertices
@@ -284,7 +295,7 @@ class TPPLPartition {
         //          vertices have to be in counter-clockwise order
         //   triangles : a list of triangles (result)
         //returns 1 on success, 0 on failure
-        int Triangulate_OPT(TPPLPoly *poly, std::list<TPPLPoly> *triangles);
+        int Triangulate_OPT(TPPLPoly *poly, TPPLPolyList *triangles);
         
         //triangulates a polygons by firstly partitioning it into monotone polygons
         //time complexity: O(n*log(n)), n is the number of vertices
@@ -294,7 +305,7 @@ class TPPLPartition {
         //          vertices have to be in counter-clockwise order
         //   triangles : a list of triangles (result)
         //returns 1 on success, 0 on failure
-        int Triangulate_MONO(TPPLPoly *poly, std::list<TPPLPoly> *triangles);
+        int Triangulate_MONO(TPPLPoly *poly, TPPLPolyList *triangles);
         
         //triangulates a list of polygons by firstly partitioning them into monotone polygons
         //time complexity: O(n*log(n)), n is the number of vertices
@@ -305,7 +316,7 @@ class TPPLPartition {
         //             vertices of all hole polys have to be in clockwise order
         //   triangles : a list of triangles (result)
         //returns 1 on success, 0 on failure
-        int Triangulate_MONO(std::list<TPPLPoly> *inpolys, std::list<TPPLPoly> *triangles);
+        int Triangulate_MONO(TPPLPolyList *inpolys, TPPLPolyList *triangles);
         
         //creates a monotone partition of a list of polygons that can contain holes
         //time complexity: O(n*log(n)), n is the number of vertices
@@ -316,7 +327,7 @@ class TPPLPartition {
         //             vertices of all hole polys have to be in clockwise order
         //   monotonePolys : a list of monotone polygons (result)
         //returns 1 on success, 0 on failure
-        int MonotonePartition(std::list<TPPLPoly> *inpolys, std::list<TPPLPoly> *monotonePolys);
+        int MonotonePartition(TPPLPolyList *inpolys, TPPLPolyList *monotonePolys);
         
         //partitions a polygon into convex polygons by using Hertel-Mehlhorn algorithm
         //the algorithm gives at most four times the number of parts as the optimal algorithm
@@ -329,7 +340,7 @@ class TPPLPartition {
         //          vertices have to be in counter-clockwise order
         //   parts : resulting list of convex polygons
         //returns 1 on success, 0 on failure
-        int ConvexPartition_HM(TPPLPoly *poly, std::list<TPPLPoly> *parts);
+        int ConvexPartition_HM(TPPLPoly *poly, TPPLPolyList *parts);
         
         //partitions a list of polygons into convex parts by using Hertel-Mehlhorn algorithm
         //the algorithm gives at most four times the number of parts as the optimal algorithm
@@ -343,7 +354,7 @@ class TPPLPartition {
         //             vertices of all hole polys have to be in clockwise order
         //   parts : resulting list of convex polygons
         //returns 1 on success, 0 on failure
-        int ConvexPartition_HM(std::list<TPPLPoly> *inpolys, std::list<TPPLPoly> *parts);
+        int ConvexPartition_HM(TPPLPolyList *inpolys, TPPLPolyList *parts);
         
         //optimal convex partitioning (in terms of number of resulting convex polygons)
         //using the Keil-Snoeyink algorithm
@@ -354,7 +365,7 @@ class TPPLPartition {
         //          vertices have to be in counter-clockwise order
         //   parts : resulting list of convex polygons
         //returns 1 on success, 0 on failure
-        int ConvexPartition_OPT(TPPLPoly *poly, std::list<TPPLPoly> *parts);
+        int ConvexPartition_OPT(TPPLPoly *poly, TPPLPolyList *parts);
 };
 
 


### PR DESCRIPTION
### Content of this PR

This adds a typedef `TPPLPolyList` and an optional (!) compiler define `TPPL_ALLOCATOR` in order to add custom allocators to `std::list` in order to improve runtime performance.

As part of this renaming of `std::list`, this PR changes `indices` inside `ConvexPartition_OPT` from `std::list`  to a `std::vector`, since it looks like this should be a vector in the first place: less memory allocations will happen, the subsequent sorting  will be faster.

### Effective Changes

Without manually defining `TPPL_ALLOCATOR`, there's no change apart from the change on `indices` just mentioned.

No changes to the API happen, as by default `TPPLPolyList` still resolves to `std::list<TPPLPoly>`, so users of polypartition see no change (they may now use `TPPLList`, but must not).

### Test and Performance

Runtime tests were done with the following code (compiled using -O3):

[main.cpp.zip](https://github.com/ivanfratric/polypartition/files/2214216/main.cpp.zip)

Using a custom allocator (Moya allocator, see https://github.com/moya-lang/Allocator), this PR improves the runtime by about 20% (from 8.4s to 6.7s for 1000000 calls to `ConvexPartition_HM`).
