### PR TITLE
Avoid realloc in TPPLPoly::Init()

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -54,9 +54,14 @@ void TPPLPoly::Clear() {
 }
 
 void TPPLPoly::Init(long numpoints) {
-	Clear();
-	this->numpoints = numpoints;
-	points = new TPPLPoint[numpoints];
+	if (numpoints <= this->numpoints) {
+		hole = false;
+		this->numpoints = numpoints;
+	} else {
+		Clear();
+		this->numpoints = numpoints;
+		points = new TPPLPoint[numpoints];		
+	}
 }
 
 void TPPLPoly::Triangle(TPPLPoint &p1, TPPLPoint &p2, TPPLPoint &p3) {


### PR DESCRIPTION
Saves some time by avoiding a realloc in TPPLPoly::Init(), which is beneficial for all functions repeatedly spitting out polygons (or triangles) of the same size.

With my test code on `ConvexPartition_HM` ([main.cpp.zip](https://github.com/ivanfratric/polypartition/files/2214259/main.cpp.zip)), this improves performance by 10% (from 8.4s to 7.7s).