### PR TITLE
Simpler and faster revert

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -103,16 +103,7 @@ void TPPLPoly::SetOrientation(int orientation) {
 }
 
 void TPPLPoly::Invert() {
-	long i;
-	TPPLPoint *invpoints = NULL;
-
-	invpoints = new TPPLPoint[numpoints];
-	for(i=0;i<numpoints;i++) {
-		invpoints[i] = points[numpoints-i-1];
-	}
-
-	delete [] points;
-	points = invpoints;
+	std::reverse(points, points + numpoints);
 }
 
 TPPLPartition::PartitionVertex::PartitionVertex() : previous(NULL), next(NULL) {


### PR DESCRIPTION
Saves one allocation (operates through swaps) and is shorter.