### PR TITLE
Add TPPLPoly::GetPoint() const

### DIFF
--- a/src/polypartition.h
+++ b/src/polypartition.h
@@ -111,6 +111,10 @@ class TPPLPoly {
             return points[i];
         }
         
+        const TPPLPoint &GetPoint(long i) const {
+            return points[i];
+        }
+
         TPPLPoint *GetPoints() {
             return points;
         }


### PR DESCRIPTION
I'm always missing this (well there's operator[] const, but that's not handy if you have a pointer to TPPLPoly).