### PR TITLE
Reuse partitionVertices buffer

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -390,7 +390,8 @@ int TPPLPartition::Triangulate_EC(TPPLPoly *poly, list<TPPLPoly> *triangles) {
 
 	numvertices = poly->GetNumPoints();
 
-	vertices = new PartitionVertex[numvertices];
+	partitionVertices.resize(numvertices);
+	vertices = partitionVertices.data();
 	for(i=0;i<numvertices;i++) {
 		vertices[i].isActive = true;
 		vertices[i].p = poly->GetPoint(i);
@@ -419,7 +420,6 @@ int TPPLPartition::Triangulate_EC(TPPLPoly *poly, list<TPPLPoly> *triangles) {
 			}
 		}
 		if(!earfound) {
-			delete [] vertices;
 			return 0;
 		}
 
@@ -442,8 +442,6 @@ int TPPLPartition::Triangulate_EC(TPPLPoly *poly, list<TPPLPoly> *triangles) {
 			break;
 		}
 	}
-
-	delete [] vertices;
 
 	return 1;
 }

--- a/src/polypartition.h
+++ b/src/polypartition.h
@@ -23,6 +23,7 @@
 
 #include <list>
 #include <set>
+#include <vector>
 
 typedef double tppl_float;
 
@@ -240,6 +241,9 @@ class TPPLPartition {
         //triangulates a monotone polygon, used in Triangulate_MONO
         int TriangulateMonotone(TPPLPoly *inPoly, std::list<TPPLPoly> *triangles);
         
+        //temporary buffer used by Triangulate_EC
+        std::vector<PartitionVertex> partitionVertices;
+
     public:
         
         //simple heuristic procedure for removing holes from a list of polygons


### PR DESCRIPTION
Saves an allocation inside `Triangulate_EC` by reusing the partition vertex buffer (and keeping it inside the `TPPLPartition`, i.e. the buffer gets reused until `TPPLPartition` gets destroyed).