### PR TITLE
Use named enums and explicit std:: instead of "using namespace std"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 #### PolyPartition
 
-PolyPartition is a lightweight C++ library for polygon partition and triangulation. PolyPartition implements multiple algorithms for both convex partitioning and triangulation. Different algorithms produce different quality of results (and their complexity varies accordingly). The implemented methods/algorithms with their advantages and disadvantages are outlined below.
+PolyPartition is a lightweight C++ library for polygon partition
+and triangulation. PolyPartition implements multiple algorithms
+for both convex partitioning and triangulation. Different
+algorithms produce different quality of results (and their
+complexity varies accordingly). The implemented methods/algorithms
+with their advantages and disadvantages are outlined below.
 
-For input parameters and return values see method declarations in `polypartition.h`. All methods require that the input polygons are not self-intersecting, and are defined in the correct vertex order (conter-clockwise for non-holes, clockwise for holes). Polygon vertices can easily be ordered correctly by calling `TPPLPoly::SetOrientation` method.
+For input parameters and return values see method declarations
+in `polypartition.h`. All methods require that the input polygons
+are not self-intersecting, are defined in the correct vertex order
+(counter-clockwise for non-holes, clockwise for holes), and any holes
+must be explicitly marked as holes (you can use `SetHole(true)`).
+Polygon vertices can easily be ordered correctly by
+calling `TPPLPoly::SetOrientation` method.
 
 Input polygon:
 
@@ -14,9 +25,9 @@ Method: `TPPLPartition::Triangulate_EC`
 
 Time/Space complexity: `O(n^2)/O(n)`
 
-Supports holes: Yes, by calling `TPPLPartition::RemoveHoles`
+Supports holes: Yes, by calling `TPPLPartition::RemoveHoles`.
 
-Quality of solution: Satisfactory in most cases
+Quality of solution: Satisfactory in most cases.
 
 Example:
 
@@ -29,9 +40,11 @@ Method: `TPPLPartition::Triangulate_OPT`
 
 Time/Space complexity: `O(n^3)/O(n^2)`
 
-Supports holes: No. You could call `TPPLPartition::RemoveHoles` prior to calling `TPPLPartition::Triangulate_OPT`, but the solution would no longer be optimal, thus defeating the purpose
+Supports holes: No. You could call `TPPLPartition::RemoveHoles` prior
+to calling `TPPLPartition::Triangulate_OPT`, but the solution would no
+longer be optimal, thus defeating the purpose.
 
-Quality of solution: Optimal in terms of minimal edge length
+Quality of solution: Optimal in terms of minimal edge length.
 
 Example:
 
@@ -46,7 +59,7 @@ Time/Space complexity: `O(n*log(n))/O(n)`
 
 Supports holes: Yes, by design
 
-Quality of solution: Poor. Many thin triangles are created in most cases
+Quality of solution: Poor. Many thin triangles are created in most cases.
 
 Example:
 
@@ -59,9 +72,11 @@ Method: `TPPLPartition::ConvexPartition_HM`
 
 Time/Space complexity: `O(n^2)/O(n)`
 
-Supports holes: Yes, by calling `TPPLPartition::RemoveHoles`
+Supports holes: Yes, by calling `TPPLPartition::RemoveHoles`.
 
-Quality of solution: At most four times the minimum number of convex polygons is created. However, in practice it works much better than that and often gives optimal partition.
+Quality of solution: At most four times the minimum number of convex
+polygons is created. However, in practice it works much better
+than that and often gives optimal partition.
 
 Example:
 
@@ -74,9 +89,11 @@ Method: `TPPLPartition::ConvexPartition_OPT`
 
 Time/Space complexity: `O(n^3)/O(n^3)`
 
-Supports holes: No. You could call `TPPLPartition::RemoveHoles` prior to calling `TPPLPartition::Triangulate_OPT`, but the solution would no longer be optimal, thus defeating the purpose
+Supports holes: No. You could call `TPPLPartition::RemoveHoles`
+prior to calling `TPPLPartition::Triangulate_OPT`, but the solution
+would no longer be optimal, thus defeating the purpose.
 
-Quality of solution: Optimal. A minimum number of convex polygons is produced
+Quality of solution: Optimal. A minimum number of convex polygons is produced.
 
 Example:
 

--- a/src/polypartition.h
+++ b/src/polypartition.h
@@ -29,8 +29,19 @@
 
 typedef double tppl_float;
 
-#define TPPL_CCW 1
-#define TPPL_CW -1
+enum TPPLOrientation {
+  TPPL_ORIENTATION_CW = -1,
+  TPPL_ORIENTATION_NONE = 0,
+  TPPL_ORIENTATION_CCW = 1,
+};
+
+enum TPPLVertexType {
+  TPPL_VERTEXTYPE_REGULAR = 0,
+  TPPL_VERTEXTYPE_START = 1,
+  TPPL_VERTEXTYPE_END = 2,
+  TPPL_VERTEXTYPE_SPLIT = 3,
+  TPPL_VERTEXTYPE_MERGE = 4,
+};
 
 // 2D point structure.
 struct TPPLPoint {
@@ -139,16 +150,18 @@ class TPPLPoly {
 
   // Returns the orientation of the polygon.
   // Possible values:
-  //    TPPL_CCW : Polygon vertices are in counter-clockwise order.
-  //    TPPL_CW : Polygon vertices are in clockwise order.
-  //        0 : The polygon has no (measurable) area.
-  int GetOrientation() const;
+  //    TPPL_ORIENTATION_CCW: Polygon vertices are in counter-clockwise order.
+  //    TPPL_ORIENTATION_CW: Polygon vertices are in clockwise order.
+  //    TPPL_ORIENTATION_NONE: The polygon has no (measurable) area.
+  TPPLOrientation GetOrientation() const;
 
   // Sets the polygon orientation.
   // Possible values:
-  //    TPPL_CCW : Sets vertices in counter-clockwise order.
-  //    TPPL_CW : Sets vertices in clockwise order.
-  void SetOrientation(int orientation);
+  //    TPPL_ORIENTATION_CCW: Sets vertices in counter-clockwise order.
+  //    TPPL_ORIENTATION_CW: Sets vertices in clockwise order.
+  //    TPPL_ORIENTATION_NONE: Reverses the orientation of the vertices if there
+  //       is one, otherwise does nothing (if orientation is already NONE).
+  void SetOrientation(TPPLOrientation orientation);
 
   // Checks whether a polygon is valid or not.
   inline bool Valid() const { return this->numpoints >= 3; }
@@ -252,7 +265,7 @@ public:
   // Helper functions for MonotonePartition.
   bool Below(TPPLPoint &p1, TPPLPoint &p2);
   void AddDiagonal(MonotoneVertex *vertices, long *numvertices, long index1, long index2,
-          char *vertextypes, std::set<ScanLineEdge>::iterator *edgeTreeIterators,
+          TPPLVertexType *vertextypes, std::set<ScanLineEdge>::iterator *edgeTreeIterators,
           std::set<ScanLineEdge> *edgeTree, long *helpers);
 
   // Triangulates a monotone polygon, used in Triangulate_MONO.


### PR DESCRIPTION
These changes increase the clarify of the API and make it harder to use it incorrectly (ex: you can't try to set an orientation of `2`).

I also updated the README with newlines and to mention that holes must be explicitly marked, which closes #41.