### PR TITLE
Remove if statements with no effect - readability-delete-null-pointer

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -35,15 +35,11 @@ TPPLPoly::TPPLPoly() {
 }
 
 TPPLPoly::~TPPLPoly() {
-  if (points) {
-    delete[] points;
-  }
+  delete[] points;
 }
 
 void TPPLPoly::Clear() {
-  if (points) {
-    delete[] points;
-  }
+  delete[] points;
   hole = false;
   numpoints = 0;
   points = NULL;


### PR DESCRIPTION
Addresses issue #47 and removes `if` statements with no effect.  See clang-tidy: https://clang.llvm.org/extra/clang-tidy/checks/readability/delete-null-pointer.html