### PR TITLE
Use closest point rather than largest x value as selection critera.

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -186,7 +186,7 @@ int TPPLPartition::RemoveHoles(TPPLPolyList *inpolys, TPPLPolyList *outpolys) {
   long i, i2, holepointindex, polypointindex;
   TPPLPoint holepoint, polypoint, bestpolypoint;
   TPPLPoint linep1, linep2;
-  TPPLPoint v1, v2;
+  tppl_float v1dist, v2dist;
   TPPLPoly newpoly;
   bool hasholes;
   bool pointvisible;
@@ -252,9 +252,9 @@ int TPPLPartition::RemoveHoles(TPPLPolyList *inpolys, TPPLPolyList *outpolys) {
         }
         polypoint = iter->GetPoint(i);
         if (pointfound) {
-          v1 = Normalize(polypoint - holepoint);
-          v2 = Normalize(bestpolypoint - holepoint);
-          if (v2.x > v1.x) {
+          v1dist = Distance(holepoint, polypoint);
+          v2dist = Distance(holepoint, bestpolypoint);
+          if (v2dist < v1dist) {
             continue;
           }
         }


### PR DESCRIPTION
This fixes [#55](https://github.com/ivanfratric/polypartition/issues/55) in which output polygons from `RemoveHoles` cause `Triangulate_EC` to fail to find an ear.

Existing tests in the repo pass. Let me know if you would like me to test on any other inputs. 