### PR TITLE
enables optional custom floating point type and sqrt function

### DIFF
--- a/src/polypartition.cpp
+++ b/src/polypartition.cpp
@@ -118,7 +118,7 @@ TPPLPartition::PartitionVertex::PartitionVertex() :
 
 TPPLPoint TPPLPartition::Normalize(const TPPLPoint &p) {
   TPPLPoint r;
-  tppl_float n = sqrt(p.x * p.x + p.y * p.y);
+  tppl_float n = tppl_sqrt(p.x * p.x + p.y * p.y);
   if (n != 0) {
     r = p / n;
   } else {
@@ -132,7 +132,7 @@ tppl_float TPPLPartition::Distance(const TPPLPoint &p1, const TPPLPoint &p2) {
   tppl_float dx, dy;
   dx = p2.x - p1.x;
   dy = p2.y - p1.y;
-  return (sqrt(dx * dx + dy * dy));
+  return (tppl_sqrt(dx * dx + dy * dy));
 }
 
 // Checks if two lines intersect.

--- a/src/polypartition.h
+++ b/src/polypartition.h
@@ -27,7 +27,12 @@
 #include <list>
 #include <set>
 
-typedef double tppl_float;
+#ifndef tppl_float
+#define tppl_float double
+#endif
+#ifndef tppl_sqrt
+#define tppl_sqrt sqrt
+#endif
 
 enum TPPLOrientation {
   TPPL_ORIENTATION_CW = -1,


### PR DESCRIPTION
This allows you to use floats instead of doubles by defining the following before including the implementation:
```
#define tppl_float float
#define tppl_sqrt std::sqrtf
```

sqrt and std::sqrtf differ at an assembly level, so this allows for extra-flexibility.